### PR TITLE
Add script to run QC reports for tables that don't have them yet

### DIFF
--- a/pheno_qc/.gitignore
+++ b/pheno_qc/.gitignore
@@ -1,0 +1,4 @@
+# Files produced when rendering the submit_qc_reports.Rmd file.
+*.html
+qc_report_data_file_*.tsv
+qc_report_submission.tsv

--- a/pheno_qc/.gitignore
+++ b/pheno_qc/.gitignore
@@ -2,3 +2,4 @@
 *.html
 qc_report_data_file_*.tsv
 qc_report_submission.tsv
+qc_report_datasets.tsv

--- a/pheno_qc/add_qc_reports_to_phenotype_harmonized_tables.Rmd
+++ b/pheno_qc/add_qc_reports_to_phenotype_harmonized_tables.Rmd
@@ -1,0 +1,118 @@
+---
+title: "Add QC reports to the phenotype_harmonized tables"
+author: "Adrienne Stilp"
+date: "`r lubridate::today()`"
+output:
+  html_document:
+    toc: true
+editor_options: 
+  chunk_output_type: console
+params:
+  update: FALSE
+---
+
+```{r}
+# Before rendering, render the submit_qc_reports.Rmd file and wait for the submitted jobs to finish.
+
+# Make sure to install the branch of the AnVIL package that has the submission id in the output.
+# AnVIL package version >= 1.17.2
+# remotes::install_github("Bioconductor/AnVIL")
+library(AnVIL)
+library(tidyverse)
+library(knitr)
+library(glue)
+
+update <- params$update
+```
+
+# Read in the output files
+
+```{r read-datasets-table}
+datasets <- read_tsv("qc_report_datasets.tsv")
+datasets %>% kable()
+```
+
+```{r read-submissions-file}
+submissions <- read_tsv("qc_report_submission.tsv")
+submissions %>% kable()
+```
+
+# (Optional) Modify for testing
+
+```{r}
+# submissions <- submissions[4,]
+# submissions$qc_data_workspace_namespace <- "primed-cc-scratch"
+# submissions$qc_data_workspace_name <- "ARIC_pheno_qc_testing"
+# 
+# datasets$workspace_namespace[datasets$workspace_namespace == "primed-data-prevent-1"] <- "primed-cc-scratch"
+# datasets$workspace_name[datasets$workspace_name == "PRIMED_ARIC_DBGAP_PHS000280_V8_P2_HMB-IRB"] <- "ARIC_pheno_qc_testing"
+```
+
+# Move the files
+
+```{r copy-submission-and-update-table, results="asis"}
+for (i in seq_along(submissions$submission_id)) {
+
+  submission_id <- submissions$submission_id[i]
+  cat(glue("\n\n## {submission_id}\n\n"))
+  
+  data_workspace_namespace <- submissions$qc_data_workspace_namespace[i]
+  data_workspace_name <- submissions$qc_data_workspace_name[i]
+
+  cat(glue("\n\n* data workspace: `{data_workspace_namespace}/{data_workspace_name}`\n\n"))
+
+  # Current submission directory.
+  this_bucket <- avbucket()
+  data_bucket <- avbucket(namespace=data_workspace_namespace, name=data_workspace_name)
+  
+  # Get the path to the QC report.
+  in_qc_report_file <- avworkflow_files(submissionId=submission_id) %>%
+    filter(file == "qc_report.html") %>%
+    pull(path)
+  
+  out_qc_report_file <- file.path(
+    data_bucket,
+    "uploaded_data_cc",
+    "auto_generated_qc_reports",
+    glue::glue("qc_report_{today}.html", today=lubridate::today())
+  )
+
+  gsutil_cp_cmd <- glue::glue("gsutil -u terra-fe86abfa cp -r {in_qc_report_file} {out_qc_report_file}")
+  
+  cat(glue("\n\n* copying from: `{in_qc_report_file}`\n\n"))
+  cat(glue("\n\n* copying to: `{out_qc_report_file}`\n\n"))
+  cat(glue("\n\n* gsutil command:\n\n```\n{gsutil_cp_cmd}\n```"))
+
+  # Prepare the update to the phenotype_harmonized data table.
+  x <- datasets %>%
+    filter(
+      workspace_namespace == data_workspace_namespace,
+      workspace_name == data_workspace_name
+    ) %>%
+    select(
+      phenotype_harmonized_id=phenotype_inventory_id,
+      qc_report
+    ) %>%
+    mutate(
+      qc_report=out_qc_report_file
+    )
+  cat("\n\n### Updates to the data table\n\n")
+  x %>% kable %>% print()
+
+  # Make the updates.
+  if (update) {
+    cat("\n\n### Copying qc report and updating phentoype_harmonized data table\n\n")
+    
+    # Copy the qc report.
+    system(gsutil_cp_cmd)
+
+    # Make sure the QC report exists in the data bucket.
+    # I think this fails if you can't specify a project?
+    # gsutil_stat(qc_report_path)
+    
+    # Update the data table.
+    avtable_import(x, namespace=data_workspace_namespace, name=data_workspace_name)
+  }
+    
+}
+```

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -9,6 +9,9 @@ params:
 ---
 
 ```{r}
+# Before submitting, import the pheno_qc workflow to the workspace.
+# Make sure to select "inputs defined by file paths" and save.
+
 # Make sure to install the branch of the AnVIL package that has the submission id in the output.
 # AnVIL package version >= 1.17.2
 # remotes::install_github("Bioconductor/AnVIL")

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -4,6 +4,8 @@ author: "Adrienne Stilp"
 date: "`r lubridate::today()`"
 editor_options: 
   chunk_output_type: console
+params:
+  submit: FALSE
 ---
 
 ```{r}
@@ -14,7 +16,7 @@ library(AnVIL)
 library(tidyverse)
 library(knitr)
 
-submit <- FALSE
+submit <- params$submit
 ```
 
 # Get list of workspaces

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -21,7 +21,7 @@ submit <- FALSE
 
 Get the list of workspaces from the primed_inventory workspace.
 
-```{r}
+```{r get-workspace-list}
 x <- avtable(
   "phenotype_inventory",
   namespace="primed-cc",
@@ -32,7 +32,7 @@ x
 
 ## Figure out which need qc reports
 
-```{r}
+```{r identify-datasets-needing-qc-reports}
 x <- x %>%
   # In case qc_report is not a column yet.
   bind_rows(tibble(qc_report=character())) %>%
@@ -41,7 +41,7 @@ x <- x %>%
 
 # Split up phenotype files by workspace
 
-```{r}
+```{r split-pheno-files-by-workspace}
 x_list <- x %>%
   group_by(workspace_namespace, workspace_name) %>%
   group_split()
@@ -52,7 +52,7 @@ x_list <- x %>%
 
 ## Pull workflow config
 
-```{r}
+```{r update-workflow-config}
   # Update workflow config.
   workflow <- file.path(avworkspace_namespace(), "pheno_qc")
   avworkflow(workflow)
@@ -62,7 +62,7 @@ x_list <- x %>%
 
 ## Prepare inputs and submit for each workspace
 
-```{r, results="asis"}
+```{r submit-workflow, results="asis"}
 submission_list <- list()
 for (i in 1:length(x_list)) {
   rows <- x_list[[i]] %>%
@@ -130,11 +130,12 @@ for (i in 1:length(x_list)) {
 
 ## Write out submission id file
 
-```{r}
+```{r print-submissions}
+submissions %>% kable()
+```
+
+```{r write-submission-id-file}
 submissions <- bind_rows(submission_list)
 write_tsv(submissions, "qc_report_submission.tsv")
 ```
 
-```{r}
-submissions %>% kable()
-```

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -1,0 +1,142 @@
+---
+title: "Add QC reports to the phenotype_harmonized tables"
+author: "Adrienne Stilp"
+date: "`r lubridate::today()`"
+editor_options: 
+  chunk_output_type: console
+---
+
+```{r}
+library(AnVIL)
+library(tidyverse)
+library(knitr)
+
+submit <- TRUE
+```
+
+# Get list of workspaces
+
+Get the list of workspaces from the primed_inventory workspace.
+
+```{r}
+x <- avtable(
+  "phenotype_inventory",
+  namespace="primed-cc",
+  name="primed_inventory"
+)
+x
+```
+
+## Figure out which need qc reports
+
+```{r}
+x <- x %>%
+  # In case qc_report is not a column yet.
+  bind_rows(tibble(qc_report=character())) %>%
+  filter(is.na(qc_report))
+```
+
+# Split up phenotype files by workspace
+
+```{r}
+x_list <- x %>%
+  group_by(workspace_namespace, workspace_name) %>%
+  group_split()
+```
+
+
+# Submit all jobs and write out submission file
+
+## Pull workflow config
+
+```{r}
+  # Update workflow config.
+  workflow <- "primed-adrienne/pheno_qc"
+  avworkflow(workflow)
+  config <- avworkflow_configuration_get()
+  config  
+```
+
+## Prepare inputs and submit for each workspace
+
+```{r, results="asis"}
+submission_list <- list()
+for (i in 1:length(x_list)) {
+  rows <- x_list[[i]] %>%
+  select(
+    phenotype_harmonized_id=phenotype_inventory_id,
+    table_names=domain,
+    file_names=file_path,
+    workspace_namespace,
+    workspace_name
+  )
+  workspace_namespace = unique(rows$workspace_namespace)
+  workspace_name = unique(rows$workspace_name)
+  
+  cat(glue::glue("\n\n### {workspace_namespace}/{workspace_name}\n\n"))
+  
+  rows %>% kable() %>% print()
+  
+  filename = glue::glue(
+    "qc_report_data_file_{workspace_namespace}_{workspace_name}.tsv",
+    workspace_namespace=unique(rows$workspace_namespace),
+    workspace_name=unique(rows$workspace_name)
+  )
+  write_tsv(rows, file=filename)
+  bucket_file <- file.path(avbucket(), filename)
+  gsutil_cp(filename, bucket_file) 
+    
+  # Prepare inputs.
+  attributes <- c(
+    "data_file" = glue::glue("\"{bucket_file}\"")
+  )
+  # Prefix the inputs with the workflow name
+  names(attributes) <- sprintf("%s.%s", basename(workflow), names(attributes))
+  
+  inputs <- avworkflow_configuration_inputs(config)
+  # Set inputs in the configuration input object.
+  inputs <- inputs %>%
+    mutate(attribute = attributes[name]) %>%
+    mutate(attribute = ifelse(is.na(attribute), "", attribute))
+  inputs %>% kable() %>% print()
+  
+  # Set workflow configuration.
+  new_config <- avworkflow_configuration_update(config, inputs)
+  new_config
+  
+  # Set the new inputs.
+  avworkflow_configuration_set(new_config, dry=FALSE)
+  # Submit workflow and save submission id.
+  if (submit) {
+    # NULL is the entityName - we are operating on files in the workspace instead of on a data table.
+    # Unfortunately this returns the config, not the submission id.
+    # Make sure to set useCallCache to FALSE!
+      avworkflow_run(new_config, NULL, useCallCache=FALSE, dry=FALSE)
+  
+    # Get the submission id. We have to call avworkflow_jobs() and pull the first.
+    # This is *likely* to be the submissionId but not guaranteed.
+    # See Issue on bioconductor AnVIL github: https://github.com/Bioconductor/AnVIL/issues/102
+    submission_list[[i]] <- avworkflow_jobs() %>%
+      slice(1) %>%
+      bind_cols(
+        tibble(
+          qc_data_workspace_namespace=workspace_namespace,
+          qc_data_workspace_name=workspace_name
+        )
+      ) %>%
+      select(qc_data_workspace_namespace, qc_data_workspace_name, submissionId, everything())
+    
+  }
+}
+```
+
+## Write out submission id file
+
+```{r}
+submissions <- bind_rows(submission_list)
+write_tsv(submissions, "qc_report_submission.tsv")
+```
+
+```{r}
+submissions %>% kable()
+```

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Add QC reports to the phenotype_harmonized tables"
+title: "Run QC reports for datasets that don't have them yet"
 author: "Adrienne Stilp"
 date: "`r lubridate::today()`"
 editor_options: 
@@ -42,6 +42,9 @@ x <- x %>%
   # In case qc_report is not a column yet.
   bind_rows(tibble(qc_report=character())) %>%
   filter(is.na(qc_report))
+
+# Save the output.
+write_tsv(x, "qc_report_datasets.tsv")
 ```
 
 # Split up phenotype files by workspace

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -8,12 +8,13 @@ editor_options:
 
 ```{r}
 # Make sure to install the branch of the AnVIL package that has the submission id in the output.
-# remotes::install_github("Bioconductor/AnVIL@workflow_run_submissionId")
+# AnVIL package version >= 1.17.2
+# remotes::install_github("Bioconductor/AnVIL")
 library(AnVIL)
 library(tidyverse)
 library(knitr)
 
-submit <- TRUE
+submit <- FALSE
 ```
 
 # Get list of workspaces
@@ -53,7 +54,7 @@ x_list <- x %>%
 
 ```{r}
   # Update workflow config.
-  workflow <- "primed-adrienne/pheno_qc"
+  workflow <- file.path(avworkspace_namespace(), "pheno_qc")
   avworkflow(workflow)
   config <- avworkflow_configuration_get()
   config  

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -7,6 +7,8 @@ editor_options:
 ---
 
 ```{r}
+# Make sure to install the branch of the AnVIL package that has the submission id in the output.
+# remotes::install_github("Bioconductor/AnVIL@workflow_run_submissionId")
 library(AnVIL)
 library(tidyverse)
 library(knitr)
@@ -77,18 +79,15 @@ for (i in 1:length(x_list)) {
   
   rows %>% kable() %>% print()
   
-  filename = glue::glue(
-    "qc_report_data_file_{workspace_namespace}_{workspace_name}.tsv",
-    workspace_namespace=unique(rows$workspace_namespace),
-    workspace_name=unique(rows$workspace_name)
-  )
+  filename = glue::glue("qc_report_data_file_{workspace_namespace}_{workspace_name}.tsv")
   write_tsv(rows, file=filename)
   bucket_file <- file.path(avbucket(), filename)
   gsutil_cp(filename, bucket_file) 
     
   # Prepare inputs.
   attributes <- c(
-    "data_file" = glue::glue("\"{bucket_file}\"")
+    "data_file" = glue::glue("\"{bucket_file}\""),
+    "workspace_name"= glue::glue("\"{workspace_name}\"")
   )
   # Prefix the inputs with the workflow name
   names(attributes) <- sprintf("%s.%s", basename(workflow), names(attributes))
@@ -111,20 +110,18 @@ for (i in 1:length(x_list)) {
     # NULL is the entityName - we are operating on files in the workspace instead of on a data table.
     # Unfortunately this returns the config, not the submission id.
     # Make sure to set useCallCache to FALSE!
-      avworkflow_run(new_config, NULL, useCallCache=FALSE, dry=FALSE)
-  
+    output <- avworkflow_run(new_config, NULL, useCallCache=FALSE, dry=FALSE)
+    
     # Get the submission id. We have to call avworkflow_jobs() and pull the first.
     # This is *likely* to be the submissionId but not guaranteed.
     # See Issue on bioconductor AnVIL github: https://github.com/Bioconductor/AnVIL/issues/102
-    submission_list[[i]] <- avworkflow_jobs() %>%
-      slice(1) %>%
-      bind_cols(
-        tibble(
-          qc_data_workspace_namespace=workspace_namespace,
-          qc_data_workspace_name=workspace_name
-        )
-      ) %>%
-      select(qc_data_workspace_namespace, qc_data_workspace_name, submissionId, everything())
+    # This is fixed in a branch!
+    job_id <- output$LastSubmissionId
+    submission_list[[i]] <- tibble(
+      submission_id = output$LastSubmissionId,
+      qc_data_workspace_namespace=workspace_namespace,
+      qc_data_workspace_name=workspace_name
+    )
     
   }
 }

--- a/pheno_qc/submit_qc_reports.Rmd
+++ b/pheno_qc/submit_qc_reports.Rmd
@@ -131,16 +131,15 @@ for (i in 1:length(x_list)) {
     
   }
 }
+
 ```
 
 ## Write out submission id file
 
-```{r print-submissions}
-submissions %>% kable()
+```{r save-submissions}
+if (submit) {
+  submissions <- bind_rows(submission_list)
+  submissions %>% kable()
+  write_tsv(submissions, "qc_report_submission.tsv")
+}
 ```
-
-```{r write-submission-id-file}
-submissions <- bind_rows(submission_list)
-write_tsv(submissions, "qc_report_submission.tsv")
-```
-


### PR DESCRIPTION
Add two Rmds:
1. Submit qc reports for all datasets in phenotype_inventory workspace that don't have one yet
2. Copy qc reports to the original data workspaces and update the phenotype_harmonized tables in those workspaces to include the path to the qc report
